### PR TITLE
Fix : 포트폴리오 필터 조회 결과 수정

### DIFF
--- a/src/main/java/com/sparta/ourportfolio/portfolio/repository/PortfolioInquiryImpl.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/repository/PortfolioInquiryImpl.java
@@ -108,7 +108,7 @@ public class PortfolioInquiryImpl extends QuerydslRepositorySupport implements P
     }
 
     private BooleanExpression ltPortfolioId(Long id) {
-        return id == null ? null : portfolio.id.between(id - 10, id);
+        return id == null ? null : portfolio.id.between(id - 9, id);
     }
 
     public Long getLastPortfolioIdByCategoryAndFilter(String category, String filter) {


### PR DESCRIPTION
- lastPortfolioId 99 입력 했을 때 89까지 조회되는 문제 해결`