### PR TITLE
Fix : 포트폴리오 ID 조회 수정, 포트폴리오 생성/수정 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     //AWS S3
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+
+    //Elastic Search
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/ourportfolio/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/controller/PortfolioController.java
@@ -48,8 +48,8 @@ public class PortfolioController {
     }
 
     @GetMapping("/id")
-    public ResponseDto<Long> getLastPortfolioId(@Nullable @RequestParam(name = "category") String category,
-                                                @Nullable @RequestParam(name = "filter") String filter) {
+    public ResponseDto<Long> getLastPortfolioId(@RequestParam(name = "category") String category,
+                                                @RequestParam(name = "filter") String filter) {
         return portfolioInquiryService.getLastPortfolioId(category, filter);
     }
     @GetMapping("/search")

--- a/src/main/java/com/sparta/ourportfolio/portfolio/dto/PortfolioResponseDto.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/dto/PortfolioResponseDto.java
@@ -11,8 +11,6 @@ public class PortfolioResponseDto {
     private String portfolioImage;
     private String userProfileImage;
     private String userName;
-    private String category;
-    private String filter;
 
     public PortfolioResponseDto(Portfolio portfolio, User user) {
         this.id = portfolio.getId();
@@ -20,7 +18,5 @@ public class PortfolioResponseDto {
         this.portfolioImage = portfolio.getPortfolioImage();
         this.userProfileImage = user.getProfileImage();
         this.userName = user.getNickname();
-        this.category = portfolio.getCategory();
-        this.filter = portfolio.getFilter();
     }
 }

--- a/src/main/java/com/sparta/ourportfolio/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/entity/Portfolio.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sparta.ourportfolio.portfolio.dto.PortfolioRequestDto;
 import com.sparta.ourportfolio.project.entity.Project;
 import com.sparta.ourportfolio.user.entity.User;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,7 +55,7 @@ public class Portfolio {
     @ManyToOne
     private User user;
 
-    public Portfolio(PortfolioRequestDto portfolioRequestDto, String imageUrl) {
+    public Portfolio(PortfolioRequestDto portfolioRequestDto, @Nullable String imageUrl) {
         this.portfolioTitle = portfolioRequestDto.getPortfolioTitle();
         this.techStack = portfolioRequestDto.getTechStack();
         this.residence = portfolioRequestDto.getResidence();

--- a/src/main/java/com/sparta/ourportfolio/portfolio/repository/PortfolioInquiryImpl.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/repository/PortfolioInquiryImpl.java
@@ -123,11 +123,12 @@ public class PortfolioInquiryImpl extends QuerydslRepositorySupport implements P
             whereBuilder.and(findByFilter(filter));
         }
 
-        return queryFactory.select(portfolio.id)
+        Long lastPortfolioId = queryFactory.select(portfolio.id)
                 .from(portfolio)
                 .where(whereBuilder)
                 .orderBy(portfolio.id.desc())
                 .fetchFirst();
+        return lastPortfolioId != null ? lastPortfolioId : -1L;
     }
 }
 

--- a/src/main/java/com/sparta/ourportfolio/portfolio/service/PortfolioInquiryService.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/service/PortfolioInquiryService.java
@@ -7,6 +7,7 @@ import com.sparta.ourportfolio.portfolio.dto.PortfolioResponseDto;
 import com.sparta.ourportfolio.portfolio.entity.Portfolio;
 import com.sparta.ourportfolio.portfolio.repository.PortfolioRepository;
 import com.sparta.ourportfolio.user.entity.User;
+import com.sparta.ourportfolio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -17,11 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static com.sparta.ourportfolio.common.exception.ExceptionEnum.NOT_FOUND_PORTFOLIO;
+import static com.sparta.ourportfolio.common.exception.ExceptionEnum.NOT_FOUND_USER;
 
 @Service
 @RequiredArgsConstructor
 public class PortfolioInquiryService {
     private final PortfolioRepository portfolioRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public ResponseDto<PortfolioDetailResponseDto> getPortfolio(Long id) {
@@ -57,6 +60,9 @@ public class PortfolioInquiryService {
 
     @Transactional(readOnly = true)
     public ResponseDto<List<PortfolioResponseDto>> getMyPortfolios(User user) {
+        User userNow = userRepository.findById(user.getId()).orElseThrow(
+                () -> new GlobalException(NOT_FOUND_USER)
+        );
         List<PortfolioResponseDto> myPortfolioList = portfolioRepository.findAllByUser_IdOrderByIdDesc(user.getId())
                 .stream()
                 .map(portfolio -> new PortfolioResponseDto(portfolio, user))
@@ -64,6 +70,7 @@ public class PortfolioInquiryService {
         return ResponseDto.set(HttpStatus.OK, "MY PORTFOLIO 조회 완료", myPortfolioList);
     }
 
+    @Transactional(readOnly = true)
     public ResponseDto<Long> getLastPortfolioId(String category, String filter) {
         Long lastPortfolioId = portfolioRepository.getLastPortfolioIdByCategoryAndFilter(category, filter) + 1;
         return ResponseDto.setSuccess(HttpStatus.OK, "Last Id 조회 완료", lastPortfolioId);

--- a/src/main/java/com/sparta/ourportfolio/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/sparta/ourportfolio/portfolio/service/PortfolioService.java
@@ -1,7 +1,6 @@
 package com.sparta.ourportfolio.portfolio.service;
 
 import com.sparta.ourportfolio.common.dto.ResponseDto;
-import com.sparta.ourportfolio.common.exception.ExceptionEnum;
 import com.sparta.ourportfolio.common.exception.GlobalException;
 import com.sparta.ourportfolio.common.utils.S3Service;
 import com.sparta.ourportfolio.portfolio.dto.PortfolioRequestDto;
@@ -38,7 +37,10 @@ public class PortfolioService {
                 () -> new GlobalException(NOT_FOUND_USER)
         );
 
-        String imageUrl = s3Service.uploadFile(image);
+        String imageUrl = null;
+        if (!image.isEmpty()) {
+            imageUrl = s3Service.uploadFile(image);
+        }
         Portfolio portfolio = new Portfolio(portfolioRequestDto, imageUrl);
 
         portfolio.setUser(userNow);
@@ -79,7 +81,10 @@ public class PortfolioService {
                 project.setPortfolio(portfolio);
             }
         }
-        String imageUrl = s3Service.uploadFile(image);
+        String imageUrl = null;
+        if (!image.isEmpty()) {
+            imageUrl = s3Service.uploadFile(image);
+        }
 
         portfolio.update(portfolioRequestDto, imageUrl);
         portfolioRepository.save(portfolio);


### PR DESCRIPTION
- ID조회 시 해당하는 포트폴리오가 없으면 0 반환
- 생성/수정 시 이미지 파일 없어도 가능 하도록 변경
- PortfolioResponseDto에서 category,filter 제거