### PR TITLE
Feat: 회원 이미지 수정 로직 변경 #26

### DIFF
--- a/src/main/generated/com/sparta/ourportfolio/portfolio/entity/QPortfolio.java
+++ b/src/main/generated/com/sparta/ourportfolio/portfolio/entity/QPortfolio.java
@@ -26,13 +26,13 @@ public class QPortfolio extends EntityPathBase<Portfolio> {
 
     public final StringPath category = createString("category");
 
-    public final StringPath experience = createString("experience");
-
     public final StringPath filter = createString("filter");
 
     public final StringPath githubId = createString("githubId");
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath intro = createString("intro");
 
     public final StringPath location = createString("location");
 

--- a/src/main/java/com/sparta/ourportfolio/user/dto/UpdateUserRequestDto.java
+++ b/src/main/java/com/sparta/ourportfolio/user/dto/UpdateUserRequestDto.java
@@ -9,8 +9,10 @@ import java.util.Optional;
 @NoArgsConstructor
 public class UpdateUserRequestDto {
     private Optional<String> nickname;
+    private String profileImage;
 
-    public UpdateUserRequestDto(Optional<String> nickname) {
+    public UpdateUserRequestDto(Optional<String> nickname, String profileImage) {
         this.nickname = nickname;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/sparta/ourportfolio/user/service/UserService.java
+++ b/src/main/java/com/sparta/ourportfolio/user/service/UserService.java
@@ -106,20 +106,10 @@ public class UserService {
         // 닉네임 수정
         if (updateUserRequestDto != null && updateUserRequestDto.getNickname() != null && !updateUserRequestDto.getNickname().isEmpty()) {
             String newNickname = updateUserRequestDto.getNickname().orElse("");
-            // 닉네임이 현재와 같은지 체크
-            if(newNickname.equals((userinfo.getNickname()))){
-                throw new GlobalException(EXISTED_NICK_NAME);
-            }
             // 중복된 닉네임이 있는지 체크
-            if(userRepository.existsByNickname(newNickname)) {
+            if (!newNickname.equals(userinfo.getNickname()) && userRepository.existsByNickname(newNickname)) {
                 throw new GlobalException(DUPLICATED_NICK_NAME);
             }
-            // 닉네임 형식이 일치하는지 체크
-            Pattern passPattern1 = Pattern.compile("^[a-zA-Z가-힣0-9]{1,10}$");
-            Matcher matcher1 = passPattern1.matcher(newNickname);
-            if(!matcher1.find()) {
-                throw new GlobalException(NICKNAME_REGEX);
-            };
             userinfo.updateNickname(newNickname);
             isUpdated = true;
         }
@@ -128,6 +118,10 @@ public class UserService {
         if (image.isPresent() && !image.get().isEmpty()) {
             String imageUrl = s3Service.uploadFile(image.get());
             userinfo.updateProfileImage(imageUrl);
+            isUpdated = true;
+        } else if (updateUserRequestDto != null && updateUserRequestDto.getProfileImage() == null) {
+            // profileImage가 null로 요청이 들어올 때 기존의 이미지를 null로 업데이트
+            userinfo.updateProfileImage(null);
             isUpdated = true;
         }
 


### PR DESCRIPTION
변경사항

- [x]  프로필 이미지만 변경했을 때 닉네임이 동일하더라도 통과시켜야할 것

- [x] 다른 사람의 닉네임과는 중복되면 안될 것

- [x] 이미지가 null로 들어올 때에는 S3에서 삭제하지말고 그냥 null로 내보낼 것